### PR TITLE
[피드] 피드 업로더 정보에 생성일 추가 및 관련 컴포넌트에서 업로더의 생성일 사용으로 수정

### DIFF
--- a/entities/feed/model/schemas.ts
+++ b/entities/feed/model/schemas.ts
@@ -10,6 +10,7 @@ export const UploaderInfoSchema = v.object({
   introduction: v.nullable(v.string()),
   profileImageUrl: v.nullable(v.string()),
   userUuid: v.string(),
+  createdAt: v.string(),
 });
 
 export type UploaderInfo = v.InferOutput<typeof UploaderInfoSchema>;

--- a/pages/feed/ui/color-feeds.tsx
+++ b/pages/feed/ui/color-feeds.tsx
@@ -155,7 +155,7 @@ function ColorFeedItem({
                   feedId={data.feedId}
                   profileImage={data.uploader.buddyImage}
                   name={data.uploader.buddyName}
-                  createdAt={data.createdAt}
+                  createdAt={data.uploader.createdAt}
                 />
               ))
             }>

--- a/pages/feed/ui/feed-detail.tsx
+++ b/pages/feed/ui/feed-detail.tsx
@@ -28,7 +28,7 @@ export default function FeedDetail({ feedId }: { feedId: number }) {
                   feedId={data.feedId}
                   profileImage={data.uploader.buddyImage}
                   name={data.uploader.buddyName}
-                  createdAt={data.createdAt}
+                  createdAt={data.uploader.createdAt}
                 />
               ))
             }

--- a/pages/feed/ui/feed-report.tsx
+++ b/pages/feed/ui/feed-report.tsx
@@ -97,7 +97,7 @@ export default function FeedReport({ data }: FeedReportProps) {
             {`${data.uploader.buddyName}${reportType === 'feed' ? "'s Post" : ''}`}
           </CustomText>
           <CustomText style={styles.reportContentDescription}>
-            {`${reportType === 'feed' ? 'Uploaded ' : 'Since '} ${format(data.createdAt, 'yyyy-MM-dd')}`}
+            {`${reportType === 'feed' ? 'Uploaded ' : 'Since '} ${format(reportType === 'feed' ? data.createdAt : data.uploader.createdAt, 'yyyy-MM-dd')}`}
           </CustomText>
         </View>
       </View>
@@ -123,6 +123,7 @@ export default function FeedReport({ data }: FeedReportProps) {
           size="xl"
           style={styles.reportFooterButton}
           disabled={
+            reportReason.length === 0 ||
             (reportReason === 'other' && reportOtherReason.length === 0) ||
             isReportFeedPending ||
             isReportUserPending

--- a/pages/home/ui/whats-new-section.tsx
+++ b/pages/home/ui/whats-new-section.tsx
@@ -131,7 +131,7 @@ function ImageSlide({ data }: ImageSlideProps) {
                     feedId={data.feedId}
                     profileImage={data.uploader.buddyImage}
                     name={data.uploader.buddyName}
-                    createdAt={data.createdAt}
+                    createdAt={data.uploader.createdAt}
                   />
                 ))
               }>

--- a/pages/profile/ui/profile-color-feeds.tsx
+++ b/pages/profile/ui/profile-color-feeds.tsx
@@ -78,7 +78,7 @@ function ProfileColorFeedsContent({
                     feedId={item.feedId}
                     profileImage={item.uploader.buddyImage}
                     name={item.uploader.buddyName}
-                    createdAt={item.createdAt}
+                    createdAt={item.uploader.createdAt}
                   />
                 ))
               }


### PR DESCRIPTION
## Reference

none

## Description

- `UploaderInfoSchema`상에 계정 생성일 추가 및 관련 내용 적용
- 이전 커밋에 들어가있어야 하는데 누락되어 추가적으로 올립니다

## Screenshot

none
